### PR TITLE
Add optional TimescaleDB Toolkit setup for the charm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,15 @@ jobs:
         run: python3 -m pip install tox
       - name: Run linters
         run: tox -e lint
+  charm-unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: python -m pip install tox
+      - name: Run unit tests
+        run: tox -e unit
   charm-integration-test:
     runs-on: ubuntu-latest
     steps:
@@ -21,7 +30,5 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           juju-channel: 3.1/stable
-      - name: Run unit tests
-        run: tox -e unit
       - name: Run integration tests
         run: tox -e integration

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Alternatively, the `juju deploy` step can be performed with custom resources:
 juju deploy timescaledb --resource deb=<path-to-tsdb-deb> --resource loader-deb=<path-to-tsdb-loader> --resource tools-deb=<path-to-tsdb-tools>
 ```
 
+[TimescaleDB Toolkit](https://github.com/timescale/timescaledb-toolkit) can also be setup by
+setting the `setup-toolkit` config to `True` or by providing the `toolkit-deb` resource if setting
+up from custom resources.
+
 ## Contributing
 Please refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,16 @@ options:
       The apt GPG key to use for installing TimescaleDB, in conjunction with
       'apt-repository'. If it does not apply, configure to empty.
     type: string
+  setup-toolkit:
+    default: False
+    description: |
+      Whether to also setup Timescale Toolkit or not.
+    type: boolean
+  toolkit-version:
+    default:
+    description: |
+      Version of TimescaleDB Toolkit to install. Leave empty for latest.
+    type: string
   version:
     default:
     description: |

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -33,6 +33,12 @@ resources:
     description: |
       Deb package for TimescaleDB tools. Must be provided if using a custom deb
       for installing (see `deb` resource).
+  toolkit-deb:
+    type: file
+    filename: timescaledb_toolkit.deb
+    description: |
+      Deb package for TimescaleDB Toolkit. If not provided, toolkit will not be
+      installed.
 series:
 - focal
 - jammy


### PR DESCRIPTION
This PR adds an option to the charm to also setup the TimescaleDB Toolkit, which provides a set of useful [hyperfunctions](https://docs.timescale.com/use-timescale/latest/hyperfunctions/).